### PR TITLE
kernel: base address を変更した

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -3,7 +3,7 @@ OBJS = main.o ascii.o
 
 CXXFLAGS += -O2 -Wall -g --target=x86_64-elf -ffreestanding -mno-red-zone \
 	    -fno-exceptions -fno-rtti -std=c++17
-LDFLAGS += --entry KernelMain -z norelro --image-base 0x100000 --static
+LDFLAGS += --entry KernelMain -z norelro --image-base 0x110000 --static
 DEPENDS = $(join $(dir $(OBJS)), $(addprefix .,$(notdir $(OBJS:.o=.d))))
 
 .PHONY: all

--- a/ndifixLoader/Main.c
+++ b/ndifixLoader/Main.c
@@ -95,7 +95,7 @@ EFI_STATUS EFIAPI UefiMain(EFI_HANDLE image_handle,
         gop->Mode->FrameBufferSize);
 
   // read kernel
-  EFI_PHYSICAL_ADDRESS kernel_base_addr = 0x100000;
+  EFI_PHYSICAL_ADDRESS kernel_base_addr = 0x110000;
   status = ReadKernel(root_dir, L"kernel.elf", kernel_base_addr);
   if (EFI_ERROR(status)) {
     Print(L"error occured while reading kernel\n");


### PR DESCRIPTION
動作させる実機で EfiConventionalMemory になってる領域を
割り当てた